### PR TITLE
feat: add keyboard shortcut to toggle plugin

### DIFF
--- a/background.js
+++ b/background.js
@@ -106,6 +106,11 @@ var getting = browser.storage.local.get(["zoomFactor", "zoomThreshold"]);
 getting.then(updateConstsFromSync);
 
 browser.browserAction.onClicked.addListener(toggle);
+browser.commands.onCommand.addListener((command) => {
+    if (command === "toggle-reszoom") {
+        toggle();
+    }
+});
 browser.tabs.onActivated.addListener(activated);
 browser.tabs.onUpdated.addListener(updated);
 browser.runtime.onMessage.addListener(resized);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "ffreszoom",
-    "version": "0.4.1",
+    "version": "0.4",
     "description": "Sets the zoom level based on the screen resolution.",
     "browser_action": {
         "default_icon": "icons/enabled.svg",

--- a/manifest.json
+++ b/manifest.json
@@ -19,5 +19,13 @@
     ],
     "options_ui": {
         "page": "options.html"
+    },
+    "commands": {
+        "toggle-reszoom": {
+            "suggested_key": {
+                "linux": "Ctrl+Alt+Z"
+            },
+            "description": "Toggle On/Off"
+        }
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "ffreszoom",
-    "version": "0.3.1",
+    "version": "0.4.1",
     "description": "Sets the zoom level based on the screen resolution.",
     "browser_action": {
         "default_icon": "icons/enabled.svg",


### PR DESCRIPTION
Add a shortcut with the default set to `Ctrl+Alt+Z` which toggles the plugin on or off by calling the `toggle()` function.

Since changing the zoom when this plugin is active is not possible (afaik), I wanted to have a quick keyboard shortcut that would disable the plugin while I changed the zoom for short time, to later re-enable it again.